### PR TITLE
feat: ensure localized metadata uses locale-specific urls

### DIFF
--- a/src/app/[locale]/about/page.tsx
+++ b/src/app/[locale]/about/page.tsx
@@ -1,2 +1,16 @@
-export { generateMetadata } from "../../about/page";
+import type { Metadata } from "next";
+
+import { localizeMetadata } from "@/lib/metadata";
+
+import { generateMetadata as baseGenerateMetadata } from "../../about/page";
+
 export { default } from "../../about/page";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const metadata = await baseGenerateMetadata();
+  return localizeMetadata(metadata, params.locale);
+}

--- a/src/app/[locale]/admin/decks/page.tsx
+++ b/src/app/[locale]/admin/decks/page.tsx
@@ -1,3 +1,17 @@
+import type { Metadata } from "next";
+
+import { localizeMetadata } from "@/lib/metadata";
+
+import { generateMetadata as baseGenerateMetadata } from "../../../admin/decks/page";
+
 export { dynamic } from "../../../admin/decks/page";
-export { generateMetadata } from "../../../admin/decks/page";
 export { default } from "../../../admin/decks/page";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const metadata = await baseGenerateMetadata();
+  return localizeMetadata(metadata, params.locale);
+}

--- a/src/app/[locale]/decks/[slug]/page.tsx
+++ b/src/app/[locale]/decks/[slug]/page.tsx
@@ -1,3 +1,20 @@
+import type { Metadata } from "next";
+
+import { localizeMetadata } from "@/lib/metadata";
+
+import { generateMetadata as baseGenerateMetadata } from "../../../decks/[slug]/page";
+
 export { generateStaticParams } from "../../../decks/[slug]/page";
-export { generateMetadata } from "../../../decks/[slug]/page";
 export { default } from "../../../decks/[slug]/page";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { locale: string; slug: string };
+}): Promise<Metadata> {
+  const metadata = await baseGenerateMetadata({
+    params: Promise.resolve({ slug: params.slug }),
+  } as Parameters<typeof baseGenerateMetadata>[0]);
+
+  return localizeMetadata(metadata, params.locale);
+}

--- a/src/app/[locale]/decks/page.tsx
+++ b/src/app/[locale]/decks/page.tsx
@@ -1,3 +1,17 @@
+import type { Metadata } from "next";
+
+import { localizeMetadata } from "@/lib/metadata";
+
+import { generateMetadata as baseGenerateMetadata } from "../../decks/page";
+
 export { revalidate } from "../../decks/page";
-export { generateMetadata } from "../../decks/page";
 export { default } from "../../decks/page";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const metadata = await baseGenerateMetadata();
+  return localizeMetadata(metadata, params.locale);
+}

--- a/src/app/[locale]/decks/upload/page.tsx
+++ b/src/app/[locale]/decks/upload/page.tsx
@@ -1,2 +1,16 @@
-export { generateMetadata } from "../../../decks/upload/page";
+import type { Metadata } from "next";
+
+import { localizeMetadata } from "@/lib/metadata";
+
+import { generateMetadata as baseGenerateMetadata } from "../../../decks/upload/page";
+
 export { default } from "../../../decks/upload/page";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const metadata = await baseGenerateMetadata();
+  return localizeMetadata(metadata, params.locale);
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,3 +1,17 @@
+import type { Metadata } from "next";
+
+import { localizeMetadata } from "@/lib/metadata";
+
+import { generateMetadata as baseGenerateMetadata } from "../page";
+
 export { revalidate } from "../page";
-export { generateMetadata } from "../page";
 export { default } from "../page";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: { locale: string };
+}): Promise<Metadata> {
+  const metadata = await baseGenerateMetadata();
+  return localizeMetadata(metadata, params.locale);
+}

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,0 +1,72 @@
+import type { Metadata } from "next";
+
+type UrlInput = string | URL;
+
+type NullableUrl = UrlInput | null | undefined;
+
+function addLocaleToPathname(pathname: string, locale: string): string {
+  if (!locale) {
+    return pathname;
+  }
+
+  if (!pathname || pathname === "/") {
+    return `/${locale}`;
+  }
+
+  if (pathname === `/${locale}` || pathname.startsWith(`/${locale}/`)) {
+    return pathname;
+  }
+
+  return `/${locale}${pathname.startsWith("/") ? pathname : `/${pathname}`}`;
+}
+
+function localizeUrlValue<T extends UrlInput>(value: T, locale: string): T {
+  if (value instanceof URL) {
+    const url = new URL(value.toString());
+    url.pathname = addLocaleToPathname(url.pathname, locale);
+    return url as T;
+  }
+
+  if (value.startsWith("http://") || value.startsWith("https://")) {
+    const url = new URL(value);
+    url.pathname = addLocaleToPathname(url.pathname, locale);
+    return url.toString() as T;
+  }
+
+  if (value.startsWith("/")) {
+    const url = new URL(value, "https://example.com");
+    url.pathname = addLocaleToPathname(url.pathname, locale);
+    const localized = `${url.pathname}${url.search}${url.hash}`;
+    return localized as T;
+  }
+
+  return value;
+}
+
+function localizeNullableUrl(value: NullableUrl, locale: string): NullableUrl {
+  if (value == null) {
+    return value;
+  }
+
+  return localizeUrlValue(value, locale);
+}
+
+export function localizeMetadata(metadata: Metadata, locale: string): Metadata {
+  const localized: Metadata = { ...metadata };
+
+  if (metadata.alternates?.canonical != null) {
+    localized.alternates = {
+      ...metadata.alternates,
+      canonical: localizeNullableUrl(metadata.alternates.canonical, locale),
+    };
+  }
+
+  if (metadata.openGraph?.url != null) {
+    localized.openGraph = {
+      ...metadata.openGraph,
+      url: localizeNullableUrl(metadata.openGraph.url, locale) ?? undefined,
+    };
+  }
+
+  return localized;
+}

--- a/tests/unit/metadata-localization.test.ts
+++ b/tests/unit/metadata-localization.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("next-intl/server", () => ({
+  getTranslations: vi.fn().mockResolvedValue((key: string) => key),
+}));
+
+vi.mock("@/i18n/navigation", () => ({
+  Link: () => null,
+  usePathname: () => "/",
+  useRouter: () => ({
+    push: () => undefined,
+    replace: () => undefined,
+    back: () => undefined,
+    forward: () => undefined,
+    refresh: () => undefined,
+    prefetch: () => Promise.resolve(),
+  }),
+  redirect: () => undefined,
+  permanentRedirect: () => undefined,
+}));
+
+describe("localized metadata wrappers", () => {
+  it("updates canonical and open graph URLs with the locale segment", async () => {
+    const { generateMetadata } = await import("@/app/[locale]/about/page");
+
+    const metadata = await generateMetadata({ params: { locale: "ru" } });
+
+    expect(metadata.alternates?.canonical).toBe("/ru/about");
+    expect(metadata.openGraph?.url).toBe("/ru/about");
+  });
+});


### PR DESCRIPTION
## Summary
- add a helper to localize metadata URLs for canonical and Open Graph fields
- update all localized page wrappers to call the base metadata and append the locale segment
- add a unit test verifying localized metadata exposes locale-specific canonical URLs

## Testing
- pnpm test -- --filter metadata-localization

------
https://chatgpt.com/codex/tasks/task_b_68d6de9f5c10832c85844c6b8cfe58f5