### PR TITLE
Add integration coverage for multipart deck uploads

### DIFF
--- a/tests/integration/api-decks.test.ts
+++ b/tests/integration/api-decks.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GET as decksGet, POST as decksPost } from "@/app/api/decks/route";
 import { __resetDeckStoreForTests } from "@/lib/deck-store";
 import type { Deck } from "@/lib/deck-schema";
 import { NextRequest } from "next/server";
+import * as captcha from "@/lib/captcha";
 
 const createDeckPayload = (overrides: Partial<Deck> = {}): Deck => ({
   title: "Integration Deck",
@@ -27,6 +28,7 @@ describe("/api/decks", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     __resetDeckStoreForTests();
   });
 
@@ -67,6 +69,90 @@ describe("/api/decks", () => {
     const searchPayload = await searchResponse.json();
 
     expect(searchPayload.items.some((item: { slug: string }) => item.slug === payload.slug)).toBe(true);
+  });
+
+  it("creates a deck from multipart uploads and returns rate limit headers", async () => {
+    const deck = createDeckPayload();
+    const formData = new FormData();
+    const file = new File([JSON.stringify(deck)], "deck.json", {
+      type: "application/json",
+    });
+    formData.append("file", file);
+    formData.append("captchaToken", "test-token");
+
+    const request = new NextRequest("http://localhost/api/decks", {
+      method: "POST",
+      body: formData,
+      headers: {
+        "x-forwarded-for": "192.0.2.1",
+      },
+    });
+
+    const response = await decksPost(request);
+    expect(response.status).toBe(200);
+
+    const payload = await response.json();
+    expect(payload.slug).toBeDefined();
+    expect(payload.importUrl).toContain("alioss://");
+
+    expect(response.headers.get("ratelimit-limit")).toBe("10");
+    expect(response.headers.get("ratelimit-remaining")).toBe("9");
+    const resetHeader = response.headers.get("ratelimit-reset");
+    expect(resetHeader).toBeTruthy();
+    if (resetHeader) {
+      expect(Number.parseInt(resetHeader, 10)).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejects multipart uploads when the file exceeds the size limit", async () => {
+    const oversizedFile = new File([new Uint8Array(5 * 1024 * 1024 + 1)], "deck.json", {
+      type: "application/json",
+    });
+    const formData = new FormData();
+    formData.append("file", oversizedFile);
+
+    const request = new NextRequest("http://localhost/api/decks", {
+      method: "POST",
+      body: formData,
+      headers: {
+        "x-forwarded-for": "198.51.100.42",
+      },
+    });
+
+    const response = await decksPost(request);
+    expect(response.status).toBe(400);
+
+    const payload = await response.json();
+    expect(payload.message).toBe("File too large");
+  });
+
+  it("returns a captcha error when verification fails for multipart uploads", async () => {
+    const deck = createDeckPayload();
+    const formData = new FormData();
+    const file = new File([JSON.stringify(deck)], "deck.json", {
+      type: "application/json",
+    });
+    formData.append("file", file);
+    formData.append("captchaToken", "invalid-token");
+
+    vi.spyOn(captcha, "verifyCaptchaToken").mockResolvedValue({
+      success: false,
+      error: "missing-token",
+    });
+
+    const request = new NextRequest("http://localhost/api/decks", {
+      method: "POST",
+      body: formData,
+      headers: {
+        "x-forwarded-for": "203.0.113.77",
+      },
+    });
+
+    const response = await decksPost(request);
+    expect(response.status).toBe(400);
+
+    const payload = await response.json();
+    expect(payload.message).toBe("Captcha required");
   });
 
   it("rejects invalid payloads", async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 
 export default defineConfig({
   resolve: {
-    ALIOSS: {
+    alias: {
       "@": path.resolve(__dirname, "src"),
     },
   },


### PR DESCRIPTION
## Summary
- add a multipart upload integration test that asserts rate limit headers
- cover oversized file rejections when the multipart payload exceeds the limit
- simulate captcha verification failures for multipart requests and reset spies between tests

## Testing
- pnpm test *(fails: Vitest cannot resolve the `@/lib/deck-store` alias in the provided configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68d6fc935fc4832ca607de52c61b96ca