### PR TITLE
Fix language switch refresh and add coverage

### DIFF
--- a/src/components/lang-switch.tsx
+++ b/src/components/lang-switch.tsx
@@ -20,6 +20,7 @@ export function LangSwitch() {
       onValueChange={(value) => {
         if (value !== locale) {
           router.replace(pathname, { locale: value as AppLocale });
+          router.refresh();
         }
       }}
     >

--- a/tests/e2e/language-switch.spec.ts
+++ b/tests/e2e/language-switch.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("language switching", () => {
+  test("updates navigation labels when a new language is selected", async ({ page }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "English" }).click();
+    await page.getByRole("option", { name: "Русский" }).click();
+
+    await expect(page.getByRole("link", { name: "Колоды" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Русский" })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- refresh the router after switching locales so navigation picks up the new language
- add a Playwright test that asserts the header labels change after selecting Russian

## Testing
- pnpm run test:e2e *(fails: missing system dependencies for Playwright)*

------
https://chatgpt.com/codex/tasks/task_b_68d829924b04832cae71a35d50f03c01